### PR TITLE
Move angular-mocks to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,10 @@
   "readmeFilename" : "README.md",
   "dependencies"   : {
     "angular"      : "~1",
-    "angular-mocks": "~1",
     "angular-route": "~1"
+  },
+  "devDependencies" : {
+    "angular-mocks": "~1"
   },
   "ignore"         : [ "**/.*", "node_modules", "test" ]
 }


### PR DESCRIPTION
When in `dependencies`, when used with wiredep, it gets injected into dist scripts.